### PR TITLE
Read bano files relative to config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,15 @@ Replaces a word only if normed version (no accent, case-insensitive) of the word
 You can provide a list of bano CSV files so that
 street and city names are added to aspell dictionary.
 
+The paths can be absolute or relative to the config path.
+
 Ex:
 ```yaml
   - IspellCheck:
       dictionnary: "fr"
       bano_files:
         - "bano/bano-75.csv"
-        - "bano/bano-77.csv"
+        - "/bano/bano-77.csv"
 ```
 
 

--- a/tests/data/conf/config-fr_idf.yml
+++ b/tests/data/conf/config-fr_idf.yml
@@ -83,20 +83,20 @@ processes:
       to: "${1}Alésia${2}"
   - RegexReplace:
       from: "(^|\\W)Ru(\\W|$)"
-      to: "${1}Rû${2}"      
+      to: "${1}Rû${2}"
     # ispell can change case
   - IspellCheck:
       dictionnary: "fr"
       bano_files:
-        - "tests/data/bano/bano-75.csv"
-        - "tests/data/bano/bano-77.csv"
-        - "tests/data/bano/bano-78.csv"
-        - "tests/data/bano/bano-91.csv"
-        - "tests/data/bano/bano-92.csv"
-        - "tests/data/bano/bano-93.csv"
-        - "tests/data/bano/bano-94.csv"
-        - "tests/data/bano/bano-95.csv"
-        - "tests/data/bano/stops_osm.csv"
+        - "../bano/bano-75.csv"
+        - "../bano/bano-77.csv"
+        - "../bano/bano-78.csv"
+        - "../bano/bano-91.csv"
+        - "../bano/bano-92.csv"
+        - "../bano/bano-93.csv"
+        - "../bano/bano-94.csv"
+        - "../bano/bano-95.csv"
+        - "../bano/stops_osm.csv"
 
   - SnakeCase
 
@@ -191,7 +191,7 @@ processes:
       to: "${1}Vaires${2}"
   - RegexReplace:
       from: "(^|\\W)Ségrais(\\W|$)"
-      to: "${1}Segrais${2}"      
+      to: "${1}Segrais${2}"
   - LogSuspicious:
       regex: "[^\\w '-/\\(\\)\\.]"
   - LogSuspicious:


### PR DESCRIPTION
In https://github.com/CanalTP/tartare we have a ruspell worker that gets config and bano files from gridfs and put it in a temporary directory.

The problem is that bano files in config.yml don't know that temporary directory.

With this PR bano files are relative to the config file so we can configure config.yml as follows
```yaml
- IspellCheck:
      dictionnary: "fr"
      bano_files:
        - "bano-75.csv"
        - "bano-77.csv"
```

and everything works like a charm